### PR TITLE
Use version when we cannot get the git revision

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: cachix/install-nix-action@v7
+    - uses: cachix/install-nix-action@v10
     - run: nix-channel --add ${{ matrix.channel }} nixpkgs
     - run: nix-channel --update
     - run: nix-build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ jobs:
       matrix:
         channel:
           - "https://nixos.org/channels/nixos-20.03"
+          - "https://nixos.org/channels/nixos-unstable"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,11 +39,15 @@ endif()
 
 set(VERSION "0.0.1")
 
-set(GIT_REVISION "unknown")
-exec_program(git
-  ARGS "log --pretty=format:\"%ad (commit: %h)\" --date=iso -1"
+execute_process(
+  COMMAND git log "--pretty=format:'%ad (commit: %h)'" --date=iso -n 1
   OUTPUT_VARIABLE GIT_REVISION 
+  ERROR_QUIET
 )
+
+if("${GIT_REVISION}" STREQUAL "")
+  set(GIT_REVISION "${VERSION}")
+endif()
 
 message(STATUS "Building revision: ${GIT_REVISION}")
 


### PR DESCRIPTION
This change avoids putting junk in GIT_REVISION when:

- git is not available (e.g. sandboxed builds)
- dact is not built from its git repository

Instead, just populate GIT_REVISION with the version in those cases.